### PR TITLE
Use gwt-client-common-bom to import dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,7 @@
 
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <gwt-client-common.version>1.4.0</gwt-client-common.version>
-    <gwt-client-common-json.version>1.3.0</gwt-client-common-json.version>
+    <gwt-client-common.version>1.5.0-SNAPSHOT</gwt-client-common.version>
 
     <imaer.version>5.0.1-2</imaer.version>
 
@@ -93,27 +92,10 @@
     <dependencies>
       <dependency>
         <groupId>nl.aerius</groupId>
-        <artifactId>gwt-client-common</artifactId>
+        <artifactId>gwt-client-common-bom</artifactId>
         <version>${gwt-client-common.version}</version>
-        <type>gwt-lib</type>
-      </dependency>
-      <dependency>
-        <groupId>nl.aerius</groupId>
-        <artifactId>gwt-client-common-json</artifactId>
-        <version>${gwt-client-common-json.version}</version>
-        <type>gwt-lib</type>
-      </dependency>
-      <dependency>
-        <groupId>nl.aerius</groupId>
-        <artifactId>gwt-client-geo-ol3</artifactId>
-        <version>${gwt-client-common.version}</version>
-        <type>gwt-lib</type>
-      </dependency>
-        <dependency>
-        <groupId>nl.aerius</groupId>
-        <artifactId>gwt-client-vue</artifactId>
-        <version>${gwt-client-common.version}</version>
-        <type>gwt-lib</type>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Switched to gwt-client-common-json version that was moved to gwt-client-common.