### PR TITLE
User newest snapshot versions, and set ui libs to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
 
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <gwt-client-common.version>1.5.0-SNAPSHOT</gwt-client-common.version>
+    <gwt-client-common.version>1.6.0-SNAPSHOT</gwt-client-common.version>
 
-    <imaer.version>5.0.1-2</imaer.version>
+    <imaer.version>5.1.0-2-SNAPSHOT</imaer.version>
 
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
   </properties>

--- a/tetris-client/pom.xml
+++ b/tetris-client/pom.xml
@@ -16,26 +16,31 @@
       <groupId>nl.aerius</groupId>
       <artifactId>imaer-shared</artifactId>
       <version>${imaer.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>nl.aerius</groupId>
       <artifactId>gwt-client-common</artifactId>
       <type>gwt-lib</type>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>nl.aerius</groupId>
       <artifactId>gwt-client-vue</artifactId>
       <type>gwt-lib</type>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>nl.aerius</groupId>
       <artifactId>gwt-client-geo-ol3</artifactId>
       <type>gwt-lib</type>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>nl.aerius</groupId>
       <artifactId>gwt-client-common-json</artifactId>
       <type>gwt-lib</type>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Because ui libraries are compiled in the application itself the dependencies can be made provided to make sure in the application the dependent libraries versions set in the application are used and not the versions set in this library.